### PR TITLE
Add prompt override support and workflow helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,8 @@ aphra/workflows/short_article/
 3. **Workflow Development:**
    - **Configuration**: Define your LLM models and parameters in `config/default.toml`
    - **API Access**: Use `context.get_workflow_config('writer')` to access model names
+   - **Prompts**: Use `self.get_prompt()` to load prompts (enables user overrides via `prompts_dir`)
+   - **Entry Point**: Implement `execute()`, not `run()` (the base `run()` handles config loading)
    - **Auto-Discovery**: Simply create the directory structure - no manual registration
    - **Self-Contained**: Keep all workflow-related code within the workflow directory
 
@@ -200,20 +202,32 @@ from ...core.workflow import AbstractWorkflow
 class MyWorkflow(AbstractWorkflow):
     def get_workflow_name(self) -> str:
         return "my_workflow"
-    
+
     def is_suitable_for(self, text: str, **kwargs) -> bool:
         # Define when this workflow should be used
         return "specific_condition" in text.lower()
-    
+
     def execute(self, context: TranslationContext, text: str) -> str:
         # Access workflow configuration
         writer_model = context.get_workflow_config('writer')
-        
-        # Implement your translation logic
-        # Call LLM: context.model_client.call_model(system, user, writer_model)
-        
-        return translated_text
+
+        # Load prompts using self.get_prompt() — this enables user overrides
+        # via the prompts_dir config option automatically
+        system_prompt = self.get_prompt('system_prompt.txt',
+                                        source_language=context.source_language,
+                                        target_language=context.target_language)
+        user_prompt = self.get_prompt('user_prompt.txt',
+                                      text=text,
+                                      source_language=context.source_language,
+                                      target_language=context.target_language)
+
+        # Call LLM
+        result = context.model_client.call_model(system_prompt, user_prompt, writer_model)
+
+        return result
 ```
+
+> **Important:** Always implement `execute()` instead of overriding `run()`. The base `run()` method handles configuration loading (including `prompts_dir` for prompt overrides). Use `self.get_prompt()` instead of importing `get_prompt()` directly so that user-defined prompt overrides work automatically.
 
 #### 3. Create Configuration File
 
@@ -291,12 +305,19 @@ api_key = "user_api_key"
 [my_workflow]
 writer = "different/model"
 custom_param = "user_value"
+
+# Users can also override or extend your prompts without modifying your code
+prompts_dir = "./my_prompts/my_workflow/"
 ```
+
+Prompt overrides work automatically when you use `self.get_prompt()` in your workflow. Users can place files in their `prompts_dir` to replace prompts entirely (same filename), append to them (`{name}_append.txt`), or prepend to them (`{name}_prepend.txt`). See the README for full details.
 
 ### Best Practices
 
 - **Self-Contained**: Keep everything related to your workflow in its directory
-- **Clear Naming**: Use descriptive names for methods and configuration parameters  
+- **Use `self.get_prompt()`**: Always load prompts through `self.get_prompt()` so users can override them via `prompts_dir`
+- **Implement `execute()`**: Never override `run()` directly — it handles config and prompt override setup
+- **Clear Naming**: Use descriptive names for methods and configuration parameters
 - **Error Handling**: Handle API failures and malformed responses gracefully
 - **Documentation**: Add docstrings explaining what your workflow does and when to use it
 - **Real Tests**: Write tests that make actual API calls to validate functionality

--- a/README.md
+++ b/README.md
@@ -426,12 +426,32 @@ critiquer = "different/model"
 ```
 
 #### 2. Prompt Customization (Simple)
-Modify the prompts within a workflow's `prompts/` folder to adapt the output for your specific use cases:
-- `aphra/workflows/short_article/prompts/step1_system.txt` - Analysis step prompts
-- `aphra/workflows/short_article/prompts/step2_system.txt` - Search step prompts  
-- `aphra/workflows/short_article/prompts/step3_system.txt` - Translation step prompts
-- `aphra/workflows/short_article/prompts/step4_system.txt` - Critique step prompts
-- `aphra/workflows/short_article/prompts/step5_system.txt` - Refinement step prompts
+
+You can override or extend any prompt without modifying Aphra's source code. Set `prompts_dir` in your `config.toml` to point to a directory with your custom prompt files:
+
+```toml
+[short_article]
+prompts_dir = "./my_prompts/short_article/"
+```
+
+Inside that directory, you have three options for each prompt file:
+
+- **Replace entirely**: create a file with the same name (e.g., `step3_system.txt`) to fully replace the default prompt.
+- **Append**: create `{name}_append.txt` (e.g., `step3_system_append.txt`) to add instructions after the default prompt.
+- **Prepend**: create `{name}_prepend.txt` (e.g., `step3_system_prepend.txt`) to add instructions before the default prompt.
+
+Append and prepend files are applied on top of the default prompt, so your customizations survive Aphra updates.
+
+All custom files support the same `{placeholders}` as the originals (e.g., `{source_language}`, `{target_language}`, `{text}`).
+
+**Example:** to instruct Aphra to preserve markdown structure and skip translator notes, create a file `my_prompts/short_article/step3_system_append.txt`:
+
+```
+Preserve all markdown formatting, headers, links, and code blocks exactly as they appear in the source.
+Do not include translator notes in the output.
+```
+
+The available prompt files for the short article workflow are: `step1_system.txt`, `step1_user.txt` (analyze), `step2_system.txt`, `step2_user.txt` (search), `step3_system.txt`, `step3_user.txt` (translate), `step4_system.txt`, `step4_user.txt` (critique), `step5_system.txt`, `step5_user.txt` (refine).
 
 #### 3. Method Customization (Intermediate)
 Customize translation behavior by inheriting from `ShortArticleWorkflow` and overriding specific methods:
@@ -467,18 +487,26 @@ from aphra.core.context import TranslationContext
 class MyWorkflow(AbstractWorkflow):
     def get_workflow_name(self) -> str:
         return "my_workflow"
-    
+
     def is_suitable_for(self, text: str, **kwargs) -> bool:
         # Define suitability criteria
         return "specific_condition" in text.lower()
-    
-    def run(self, context: TranslationContext, text: str) -> str:
+
+    def execute(self, context: TranslationContext, text: str) -> str:
         # Access workflow configuration
         writer_model = context.get_workflow_config('writer')
-        
+
+        # Load prompts using self.get_prompt() — this enables user overrides
+        # via the prompts_dir config option automatically
+        system_prompt = self.get_prompt('step1_system.txt',
+                                        source_language=context.source_language,
+                                        target_language=context.target_language)
+
         # Your complete workflow logic here
         return translated_text
 ```
+
+> **Note:** Always implement `execute()` instead of `run()`. The base `run()` method handles configuration loading (including `prompts_dir`). Use `self.get_prompt()` instead of importing `get_prompt()` directly — this ensures that user-defined prompt overrides work automatically.
 
 Create configuration file `aphra/workflows/my_workflow/config/default.toml`:
 

--- a/README.md
+++ b/README.md
@@ -502,11 +502,13 @@ class MyWorkflow(AbstractWorkflow):
                                         source_language=context.source_language,
                                         target_language=context.target_language)
 
+        # Build the user prompt
+        user_prompt = self.get_prompt('step1_user.txt', text=text)
+
         # Call the model and return the result
         result = context.model_client.call_model(
-            model=writer_model,
-            system=system_prompt,
-            prompt=text
+            system_prompt, user_prompt, writer_model,
+            log_call=context.log_calls
         )
         return result
 ```

--- a/README.md
+++ b/README.md
@@ -502,8 +502,13 @@ class MyWorkflow(AbstractWorkflow):
                                         source_language=context.source_language,
                                         target_language=context.target_language)
 
-        # Your complete workflow logic here
-        return translated_text
+        # Call the model and return the result
+        result = context.model_client.call_model(
+            model=writer_model,
+            system=system_prompt,
+            prompt=text
+        )
+        return result
 ```
 
 > **Note:** Always implement `execute()` instead of `run()`. The base `run()` method handles configuration loading (including `prompts_dir`). Use `self.get_prompt()` instead of importing `get_prompt()` directly — this ensures that user-defined prompt overrides work automatically.

--- a/aphra/core/prompts.py
+++ b/aphra/core/prompts.py
@@ -38,7 +38,9 @@ def _validate_name(value: str, label: str) -> None:
     Raises:
         ValueError: If the name contains path traversal components
     """
-    if (os.path.basename(value) != value
+    if (not value
+            or value in (os.curdir, os.pardir, '.', '..')
+            or os.path.basename(value) != value
             or os.path.isabs(value)
             or ntpath.splitdrive(value)[0]):
         raise ValueError(

--- a/aphra/core/prompts.py
+++ b/aphra/core/prompts.py
@@ -26,6 +26,27 @@ from importlib import resources
 logger = logging.getLogger(__name__)
 
 
+def _validate_name(value: str, label: str) -> None:
+    """
+    Validate that a name is a plain identifier without path separators,
+    absolute paths, or Windows drive letters.
+
+    Args:
+        value: The name to validate
+        label: Human-readable label for error messages (e.g., 'prompt file name')
+
+    Raises:
+        ValueError: If the name contains path traversal components
+    """
+    if (os.path.basename(value) != value
+            or os.path.isabs(value)
+            or ntpath.splitdrive(value)[0]):
+        raise ValueError(
+            f"Invalid {label}: '{value}'. "
+            f"Must be a plain name without path separators."
+        )
+
+
 def _load_default_prompt(workflow_name: str, file_name: str) -> str:
     """
     Load a prompt template from the workflow's built-in prompts directory.
@@ -121,13 +142,10 @@ def get_prompt(workflow_name: str, file_name: str, prompts_dir: Optional[str] = 
     Raises:
         FileNotFoundError: If the default prompt file doesn't exist
         KeyError: If required format parameters are missing
-        ValueError: If file_name contains path separators or is an absolute path
+        ValueError: If workflow_name or file_name contain path separators or traversal components
     """
-    # Reject path traversal attempts (including Windows drive-relative paths like "C:foo.txt")
-    if (os.path.basename(file_name) != file_name
-            or os.path.isabs(file_name)
-            or ntpath.splitdrive(file_name)[0]):
-        raise ValueError(f"Invalid prompt file name: '{file_name}'. Must be a plain filename without path separators.")
+    _validate_name(workflow_name, "workflow name")
+    _validate_name(file_name, "prompt file name")
 
     base_name = os.path.splitext(file_name)[0]
 
@@ -174,11 +192,15 @@ def list_workflow_prompts(workflow_name: str) -> List[str]:
 
     Raises:
         FileNotFoundError: If the workflow prompts directory doesn't exist
+        ValueError: If workflow_name contains path separators or traversal components
     """
+    _validate_name(workflow_name, "workflow name")
+
     try:
         # Try using importlib.resources first
         prompts_ref = resources.files('aphra.workflows') / workflow_name / 'prompts'
-        return [f.name for f in prompts_ref.iterdir() if f.is_file()]
+        return [f.name for f in prompts_ref.iterdir()
+                if f.is_file() and f.name.endswith('.txt')]
     except (AttributeError, FileNotFoundError) as exc:
         # Fallback to direct directory access
         workflows_path = os.path.dirname(os.path.dirname(__file__))
@@ -189,4 +211,5 @@ def list_workflow_prompts(workflow_name: str) -> List[str]:
             raise FileNotFoundError(msg) from exc
 
         return [f for f in os.listdir(prompts_path)
-                if os.path.isfile(os.path.join(prompts_path, f))]
+                if os.path.isfile(os.path.join(prompts_path, f))
+                and f.endswith('.txt')]

--- a/aphra/core/prompts.py
+++ b/aphra/core/prompts.py
@@ -3,54 +3,155 @@ Core prompt template loading utilities.
 
 This module provides generic prompt template loading functionality
 for all workflows in the Aphra translation system.
+
+Supports user-defined prompt overrides via the `prompts_dir` configuration option.
+When a prompts_dir is set in the workflow config, prompts are resolved as follows:
+
+    1. If `{prompts_dir}/{file_name}` exists → full override (replaces the default prompt)
+    2. Otherwise, the default prompt is loaded from the package, and:
+       - If `{prompts_dir}/{base}_prepend.txt` exists → its content is prepended
+       - If `{prompts_dir}/{base}_append.txt` exists → its content is appended
+
+    Where `{base}` is the file name without extension (e.g., 'step3_system' for 'step3_system.txt').
+
+All prompt files (default, override, prepend, append) support the same {placeholder} variables.
 """
 
 import os
+import logging
 from importlib import resources
 
-def get_prompt(workflow_name: str, file_name: str, **kwargs) -> str:
+logger = logging.getLogger(__name__)
+
+
+def _load_default_prompt(workflow_name: str, file_name: str) -> str:
     """
-    Reads a prompt template from a workflow's prompts directory and formats it.
+    Load a prompt template from the workflow's built-in prompts directory.
 
     Args:
-        workflow_name: Name of the workflow (e.g., 'short_article', 'subtitles')
+        workflow_name: Name of the workflow (e.g., 'short_article')
         file_name: Name of the prompt file (e.g., 'step1_system.txt')
-        **kwargs: Optional keyword arguments to format the prompt template
 
     Returns:
-        str: The formatted prompt content
+        str: The raw prompt content
 
     Raises:
         FileNotFoundError: If the prompt file doesn't exist
-        KeyError: If required format parameters are missing
     """
     try:
         # Try using importlib.resources first (works in packaged installations)
         ref = resources.files('aphra.workflows') / workflow_name / 'prompts' / file_name
         with ref.open('r', encoding="utf-8") as file:
-            content = file.read()
+            return file.read()
     except (AttributeError, FileNotFoundError) as exc:
         # Fallback to direct file access (works in development)
-        workflows_path = os.path.dirname(os.path.dirname(__file__))  # Go up to aphra/
+        workflows_path = os.path.dirname(os.path.dirname(__file__))
         file_path = os.path.join(workflows_path, 'workflows', workflow_name, 'prompts', file_name)
 
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"Prompt file not found: {file_path}") from exc
 
         with open(file_path, 'r', encoding="utf-8") as file:
-            content = file.read()
+            return file.read()
 
-    # Format the content with provided kwargs if any
+
+def _read_file_if_exists(file_path: str) -> str:
+    """
+    Read a file and return its content, or return None if it doesn't exist.
+
+    Args:
+        file_path: Absolute or relative path to the file
+
+    Returns:
+        str or None: File content, or None if the file doesn't exist
+    """
+    if os.path.isfile(file_path):
+        with open(file_path, 'r', encoding="utf-8") as file:
+            return file.read()
+    return None
+
+
+def _format_prompt(content: str, workflow_name: str, file_name: str, **kwargs) -> str:
+    """
+    Apply format placeholders to a prompt string.
+
+    Args:
+        content: The raw prompt content with {placeholders}
+        workflow_name: Workflow name (for error messages)
+        file_name: File name (for error messages)
+        **kwargs: Placeholder values
+
+    Returns:
+        str: The formatted prompt
+    """
     if kwargs:
         try:
-            formatted_prompt = content.format(**kwargs)
+            return content.format(**kwargs)
         except KeyError as exc:
             msg = f"Missing format parameter {exc} for prompt {workflow_name}/{file_name}"
             raise KeyError(msg) from exc
-    else:
-        formatted_prompt = content
+    return content
 
-    return formatted_prompt
+
+def get_prompt(workflow_name: str, file_name: str, prompts_dir: str = None, **kwargs) -> str:
+    """
+    Load a prompt template, applying user overrides if configured.
+
+    Resolution order when prompts_dir is set:
+        1. Full override: {prompts_dir}/{file_name} replaces the default entirely
+        2. Extend: default prompt with optional prepend/append from:
+           - {prompts_dir}/{base}_prepend.txt (added before the default)
+           - {prompts_dir}/{base}_append.txt (added after the default)
+
+    When prompts_dir is not set, the default prompt from the package is used as-is.
+
+    All files support the same {placeholder} format variables.
+
+    Args:
+        workflow_name: Name of the workflow (e.g., 'short_article', 'subtitles')
+        file_name: Name of the prompt file (e.g., 'step1_system.txt')
+        prompts_dir: Optional path to a directory with prompt overrides
+        **kwargs: Optional keyword arguments to format the prompt template
+
+    Returns:
+        str: The formatted prompt content
+
+    Raises:
+        FileNotFoundError: If the default prompt file doesn't exist
+        KeyError: If required format parameters are missing
+    """
+    base_name = os.path.splitext(file_name)[0]
+
+    if prompts_dir:
+        # Check for full override
+        override_path = os.path.join(prompts_dir, file_name)
+        override_content = _read_file_if_exists(override_path)
+
+        if override_content is not None:
+            logger.debug("Using prompt override: %s/%s", prompts_dir, file_name)
+            return _format_prompt(override_content, workflow_name, file_name, **kwargs)
+
+        # Load default and apply prepend/append
+        content = _load_default_prompt(workflow_name, file_name)
+
+        prepend_path = os.path.join(prompts_dir, f"{base_name}_prepend.txt")
+        prepend_content = _read_file_if_exists(prepend_path)
+        if prepend_content is not None:
+            logger.debug("Prepending to prompt: %s/%s_prepend.txt", prompts_dir, base_name)
+            content = prepend_content + "\n\n" + content
+
+        append_path = os.path.join(prompts_dir, f"{base_name}_append.txt")
+        append_content = _read_file_if_exists(append_path)
+        if append_content is not None:
+            logger.debug("Appending to prompt: %s/%s_append.txt", prompts_dir, base_name)
+            content = content + "\n\n" + append_content
+
+        return _format_prompt(content, workflow_name, file_name, **kwargs)
+
+    # No overrides — load default prompt
+    content = _load_default_prompt(workflow_name, file_name)
+    return _format_prompt(content, workflow_name, file_name, **kwargs)
+
 
 def list_workflow_prompts(workflow_name: str) -> list[str]:
     """

--- a/aphra/core/prompts.py
+++ b/aphra/core/prompts.py
@@ -19,7 +19,7 @@ All prompt files (default, override, prepend, append) support the same {placehol
 
 import os
 import logging
-from typing import Optional
+from typing import List, Optional
 from importlib import resources
 
 logger = logging.getLogger(__name__)
@@ -120,7 +120,12 @@ def get_prompt(workflow_name: str, file_name: str, prompts_dir: Optional[str] = 
     Raises:
         FileNotFoundError: If the default prompt file doesn't exist
         KeyError: If required format parameters are missing
+        ValueError: If file_name contains path separators or is an absolute path
     """
+    # Reject path traversal attempts
+    if os.path.basename(file_name) != file_name or os.path.isabs(file_name):
+        raise ValueError(f"Invalid prompt file name: '{file_name}'. Must be a plain filename without path separators.")
+
     base_name = os.path.splitext(file_name)[0]
 
     if prompts_dir:
@@ -154,7 +159,7 @@ def get_prompt(workflow_name: str, file_name: str, prompts_dir: Optional[str] = 
     return _format_prompt(content, workflow_name, file_name, **kwargs)
 
 
-def list_workflow_prompts(workflow_name: str) -> list[str]:
+def list_workflow_prompts(workflow_name: str) -> List[str]:
     """
     List all available prompt files for a workflow.
 

--- a/aphra/core/prompts.py
+++ b/aphra/core/prompts.py
@@ -18,6 +18,7 @@ All prompt files (default, override, prepend, append) support the same {placehol
 """
 
 import os
+import ntpath
 import logging
 from typing import List, Optional
 from importlib import resources
@@ -122,8 +123,10 @@ def get_prompt(workflow_name: str, file_name: str, prompts_dir: Optional[str] = 
         KeyError: If required format parameters are missing
         ValueError: If file_name contains path separators or is an absolute path
     """
-    # Reject path traversal attempts
-    if os.path.basename(file_name) != file_name or os.path.isabs(file_name):
+    # Reject path traversal attempts (including Windows drive-relative paths like "C:foo.txt")
+    if (os.path.basename(file_name) != file_name
+            or os.path.isabs(file_name)
+            or ntpath.splitdrive(file_name)[0]):
         raise ValueError(f"Invalid prompt file name: '{file_name}'. Must be a plain filename without path separators.")
 
     base_name = os.path.splitext(file_name)[0]

--- a/aphra/core/prompts.py
+++ b/aphra/core/prompts.py
@@ -38,11 +38,12 @@ def _validate_name(value: str, label: str) -> None:
     Raises:
         ValueError: If the name contains path traversal components
     """
-    if (not value
-            or value in (os.curdir, os.pardir, '.', '..')
-            or os.path.basename(value) != value
-            or os.path.isabs(value)
-            or ntpath.splitdrive(value)[0]):
+    is_empty_or_special = not value or value in (os.curdir, os.pardir, '.', '..')
+    has_separators = (os.path.basename(value) != value
+                      or ntpath.basename(value) != value)
+    is_absolute_or_drive = os.path.isabs(value) or ntpath.splitdrive(value)[0]
+
+    if is_empty_or_special or has_separators or is_absolute_or_drive:
         raise ValueError(
             f"Invalid {label}: '{value}'. "
             f"Must be a plain name without path separators."

--- a/aphra/core/prompts.py
+++ b/aphra/core/prompts.py
@@ -19,6 +19,7 @@ All prompt files (default, override, prepend, append) support the same {placehol
 
 import os
 import logging
+from typing import Optional
 from importlib import resources
 
 logger = logging.getLogger(__name__)
@@ -55,7 +56,7 @@ def _load_default_prompt(workflow_name: str, file_name: str) -> str:
             return file.read()
 
 
-def _read_file_if_exists(file_path: str) -> str:
+def _read_file_if_exists(file_path: str) -> Optional[str]:
     """
     Read a file and return its content, or return None if it doesn't exist.
 
@@ -63,7 +64,7 @@ def _read_file_if_exists(file_path: str) -> str:
         file_path: Absolute or relative path to the file
 
     Returns:
-        str or None: File content, or None if the file doesn't exist
+        File content, or None if the file doesn't exist
     """
     if os.path.isfile(file_path):
         with open(file_path, 'r', encoding="utf-8") as file:
@@ -93,7 +94,7 @@ def _format_prompt(content: str, workflow_name: str, file_name: str, **kwargs) -
     return content
 
 
-def get_prompt(workflow_name: str, file_name: str, prompts_dir: str = None, **kwargs) -> str:
+def get_prompt(workflow_name: str, file_name: str, prompts_dir: Optional[str] = None, **kwargs) -> str:
     """
     Load a prompt template, applying user overrides if configured.
 

--- a/aphra/core/workflow.py
+++ b/aphra/core/workflow.py
@@ -22,9 +22,11 @@ class AbstractWorkflow(ABC):
     enabling user-defined prompt overrides without modifying workflow code.
     """
 
+    _prompts_dir: Optional[str] = None
+
     def __init__(self):
         """Initialize the workflow with default state."""
-        self._prompts_dir: Optional[str] = None
+        self._prompts_dir = None
 
     def get_prompt(self, file_name: str, **kwargs) -> str:
         """
@@ -40,7 +42,8 @@ class AbstractWorkflow(ABC):
         Returns:
             str: The formatted prompt content
         """
-        return _get_prompt(self.get_workflow_name(), file_name, prompts_dir=self._prompts_dir, **kwargs)
+        prompts_dir = getattr(self, '_prompts_dir', None)
+        return _get_prompt(self.get_workflow_name(), file_name, prompts_dir=prompts_dir, **kwargs)
 
     @abstractmethod
     def get_workflow_name(self) -> str:

--- a/aphra/core/workflow.py
+++ b/aphra/core/workflow.py
@@ -5,7 +5,7 @@ This module defines the contract for translation workflows.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from .context import TranslationContext
 from .config import load_workflow_config
 from .prompts import get_prompt as _get_prompt
@@ -22,7 +22,9 @@ class AbstractWorkflow(ABC):
     enabling user-defined prompt overrides without modifying workflow code.
     """
 
-    _prompts_dir = None
+    def __init__(self):
+        """Initialize the workflow with default state."""
+        self._prompts_dir: Optional[str] = None
 
     def get_prompt(self, file_name: str, **kwargs) -> str:
         """
@@ -38,8 +40,7 @@ class AbstractWorkflow(ABC):
         Returns:
             str: The formatted prompt content
         """
-        prompts_dir = getattr(self, '_prompts_dir', None)
-        return _get_prompt(self.get_workflow_name(), file_name, prompts_dir=prompts_dir, **kwargs)
+        return _get_prompt(self.get_workflow_name(), file_name, prompts_dir=self._prompts_dir, **kwargs)
 
     @abstractmethod
     def get_workflow_name(self) -> str:

--- a/aphra/core/workflow.py
+++ b/aphra/core/workflow.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, Any
 from .context import TranslationContext
 from .config import load_workflow_config
+from .prompts import get_prompt as _get_prompt
 
 class AbstractWorkflow(ABC):
     """
@@ -15,7 +16,30 @@ class AbstractWorkflow(ABC):
 
     A workflow orchestrates a translation process for a specific type of content
     using methods that can be overridden to customize behavior.
+
+    Subclasses can use self.get_prompt() instead of importing get_prompt() directly.
+    This method automatically injects the prompts_dir from the workflow config,
+    enabling user-defined prompt overrides without modifying workflow code.
     """
+
+    _prompts_dir = None
+
+    def get_prompt(self, file_name: str, **kwargs) -> str:
+        """
+        Load a prompt template for this workflow, with override support.
+
+        This is a convenience wrapper around core.prompts.get_prompt() that
+        automatically provides the workflow name and prompts_dir from config.
+
+        Args:
+            file_name: Name of the prompt file (e.g., 'step1_system.txt')
+            **kwargs: Format placeholders for the prompt template
+
+        Returns:
+            str: The formatted prompt content
+        """
+        prompts_dir = getattr(self, '_prompts_dir', None)
+        return _get_prompt(self.get_workflow_name(), file_name, prompts_dir=prompts_dir, **kwargs)
 
     @abstractmethod
     def get_workflow_name(self) -> str:
@@ -75,6 +99,9 @@ class AbstractWorkflow(ABC):
         # Load workflow configuration and set it in context
         workflow_config = self.load_config()
         context.set_workflow_config(workflow_config)
+
+        # Store prompts_dir for use by self.get_prompt()
+        self._prompts_dir = workflow_config.get('prompts_dir')
 
         # Get text from context if not provided
         if text is None:

--- a/aphra/workflows/short_article/short_article_workflow.py
+++ b/aphra/workflows/short_article/short_article_workflow.py
@@ -7,7 +7,6 @@ and similar content types.
 
 from typing import List, Dict, Any
 from ...core.context import TranslationContext
-from ...core.prompts import get_prompt
 from ...core.workflow import AbstractWorkflow
 from .aux.parsers import parse_analysis, parse_translation
 
@@ -63,15 +62,13 @@ class ShortArticleWorkflow(AbstractWorkflow):
         writer_model = context.get_workflow_config('writer')
 
         # Get prompts for analysis
-        system_prompt = get_prompt(
-            'short_article',
+        system_prompt = self.get_prompt(
             'step1_system.txt',
             post_content=text,
             source_language=context.source_language,
             target_language=context.target_language
         )
-        user_prompt = get_prompt(
-            'short_article',
+        user_prompt = self.get_prompt(
             'step1_user.txt',
             post_content=text,
             source_language=context.source_language,
@@ -135,15 +132,13 @@ class ShortArticleWorkflow(AbstractWorkflow):
         writer_model = context.get_workflow_config('writer')
 
         # Get prompts for translation
-        system_prompt = get_prompt(
-            'short_article',
+        system_prompt = self.get_prompt(
             'step3_system.txt',
             text=text,
             source_language=context.source_language,
             target_language=context.target_language
         )
-        user_prompt = get_prompt(
-            'short_article',
+        user_prompt = self.get_prompt(
             'step3_user.txt',
             text=text,
             source_language=context.source_language,
@@ -176,8 +171,7 @@ class ShortArticleWorkflow(AbstractWorkflow):
         critiquer_model = context.get_workflow_config('critiquer')
 
         # Get prompts for critique
-        system_prompt = get_prompt(
-            'short_article',
+        system_prompt = self.get_prompt(
             'step4_system.txt',
             text=text,
             translation=translation,
@@ -185,8 +179,7 @@ class ShortArticleWorkflow(AbstractWorkflow):
             source_language=context.source_language,
             target_language=context.target_language
         )
-        user_prompt = get_prompt(
-            'short_article',
+        user_prompt = self.get_prompt(
             'step4_user.txt',
             text=text,
             translation=translation,
@@ -222,8 +215,7 @@ class ShortArticleWorkflow(AbstractWorkflow):
         writer_model = context.get_workflow_config('writer')
 
         # Get prompts for refinement
-        system_prompt = get_prompt(
-            'short_article',
+        system_prompt = self.get_prompt(
             'step5_system.txt',
             text=text,
             translation=translation,
@@ -232,8 +224,7 @@ class ShortArticleWorkflow(AbstractWorkflow):
             source_language=context.source_language,
             target_language=context.target_language
         )
-        user_prompt = get_prompt(
-            'short_article',
+        user_prompt = self.get_prompt(
             'step5_user.txt',
             text=text,
             translation=translation,
@@ -298,16 +289,14 @@ class ShortArticleWorkflow(AbstractWorkflow):
         Returns:
             str: The generated explanation with web search results
         """
-        system_prompt = get_prompt(
-            'short_article',
+        system_prompt = self.get_prompt(
             'step2_system.txt',
             term=item['name'],
             keywords=", ".join(item['keywords']),
             source_language=context.source_language,
             target_language=context.target_language
         )
-        user_prompt = get_prompt(
-            'short_article',
+        user_prompt = self.get_prompt(
             'step2_user.txt',
             term=item['name'],
             keywords=", ".join(item['keywords']),

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,3 +8,22 @@ api_key = "your_openrouter_api_key_here"
 writer = "anthropic/claude-sonnet-4"
 searcher = "perplexity/sonar"
 critiquer = "anthropic/claude-sonnet-4"
+
+# Prompt overrides (optional)
+# Point to a directory with custom prompt files to override or extend the defaults.
+# prompts_dir = "./my_prompts/short_article/"
+#
+# Inside that directory you can:
+#   - Replace a prompt entirely: create a file with the same name (e.g. step3_system.txt)
+#   - Append to a prompt: create {name}_append.txt (e.g. step3_system_append.txt)
+#   - Prepend to a prompt: create {name}_prepend.txt (e.g. step3_system_prepend.txt)
+#
+# Override files support the same {placeholders} as the originals
+# (e.g. {source_language}, {target_language}, {text}, {translation}, etc.)
+#
+# Available prompt files for this workflow:
+#   step1_system.txt / step1_user.txt  (analyze)
+#   step2_system.txt / step2_user.txt  (search)
+#   step3_system.txt / step3_user.txt  (translate)
+#   step4_system.txt / step4_user.txt  (critique)
+#   step5_system.txt / step5_user.txt  (refine)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ packages = [
     { include = "aphra" }
 ]
 include = [
-    "aphra/prompts/*.txt"
+    "aphra/workflows/*/prompts/*.txt",
+    "aphra/workflows/*/config/*.toml"
 ]
 
 [tool.poetry.dependencies]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,10 @@ setup(
         ],
     },
     package_data={
-        'aphra': ['prompts/*.txt'],
+        'aphra': [
+            'workflows/*/prompts/*.txt',
+            'workflows/*/config/*.toml',
+        ],
     },
     include_package_data=True,
     description='A translation package using LLMs',

--- a/tests/test_core_prompts.py
+++ b/tests/test_core_prompts.py
@@ -2,9 +2,11 @@
 Test cases for the core prompt system.
 
 These tests verify the generic prompt loading functionality that can be used
-across all workflows.
+across all workflows, including the prompt override system (prompts_dir).
 """
 
+import os
+import tempfile
 import unittest
 from aphra.core.prompts import get_prompt, list_workflow_prompts
 
@@ -98,6 +100,143 @@ class TestCorePrompts(unittest.TestCase):
         # All files should have .txt extension
         for prompt_file in prompts:
             self.assertTrue(prompt_file.endswith('.txt'))
+
+
+class TestPromptOverrides(unittest.TestCase):
+    """
+    Test cases for the prompt override system (prompts_dir).
+    """
+
+    def setUp(self):
+        """Create a temporary directory for prompt overrides."""
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        for f in os.listdir(self.tmpdir):
+            os.remove(os.path.join(self.tmpdir, f))
+        os.rmdir(self.tmpdir)
+
+    def test_full_override(self):
+        """
+        Test that a file in prompts_dir completely replaces the default prompt.
+        """
+        override_content = "Custom prompt for {source_language} to {target_language}."
+        override_path = os.path.join(self.tmpdir, 'step1_system.txt')
+        with open(override_path, 'w', encoding='utf-8') as f:
+            f.write(override_content)
+
+        result = get_prompt('short_article', 'step1_system.txt',
+                           prompts_dir=self.tmpdir,
+                           source_language='Spanish',
+                           target_language='English')
+
+        self.assertEqual(result, "Custom prompt for Spanish to English.")
+
+    def test_append(self):
+        """
+        Test that an _append file adds content after the default prompt.
+        """
+        append_content = "APPENDED INSTRUCTION"
+        append_path = os.path.join(self.tmpdir, 'step1_system_append.txt')
+        with open(append_path, 'w', encoding='utf-8') as f:
+            f.write(append_content)
+
+        result = get_prompt('short_article', 'step1_system.txt',
+                           prompts_dir=self.tmpdir)
+
+        # Default prompt should be there, followed by the appended content
+        self.assertTrue(result.endswith("APPENDED INSTRUCTION"))
+        self.assertGreater(len(result), len(append_content))
+
+    def test_prepend(self):
+        """
+        Test that a _prepend file adds content before the default prompt.
+        """
+        prepend_content = "PREPENDED INSTRUCTION"
+        prepend_path = os.path.join(self.tmpdir, 'step1_system_prepend.txt')
+        with open(prepend_path, 'w', encoding='utf-8') as f:
+            f.write(prepend_content)
+
+        result = get_prompt('short_article', 'step1_system.txt',
+                           prompts_dir=self.tmpdir)
+
+        # Prepended content should be at the start
+        self.assertTrue(result.startswith("PREPENDED INSTRUCTION"))
+        self.assertGreater(len(result), len(prepend_content))
+
+    def test_prepend_and_append_together(self):
+        """
+        Test that prepend and append can be used simultaneously.
+        """
+        prepend_path = os.path.join(self.tmpdir, 'step1_system_prepend.txt')
+        with open(prepend_path, 'w', encoding='utf-8') as f:
+            f.write("BEFORE")
+
+        append_path = os.path.join(self.tmpdir, 'step1_system_append.txt')
+        with open(append_path, 'w', encoding='utf-8') as f:
+            f.write("AFTER")
+
+        result = get_prompt('short_article', 'step1_system.txt',
+                           prompts_dir=self.tmpdir)
+
+        self.assertTrue(result.startswith("BEFORE"))
+        self.assertTrue(result.endswith("AFTER"))
+
+    def test_override_takes_priority_over_append(self):
+        """
+        Test that a full override ignores append/prepend files.
+        """
+        # Create all three: override, append, prepend
+        override_path = os.path.join(self.tmpdir, 'step1_system.txt')
+        with open(override_path, 'w', encoding='utf-8') as f:
+            f.write("OVERRIDE ONLY")
+
+        append_path = os.path.join(self.tmpdir, 'step1_system_append.txt')
+        with open(append_path, 'w', encoding='utf-8') as f:
+            f.write("SHOULD NOT APPEAR")
+
+        result = get_prompt('short_article', 'step1_system.txt',
+                           prompts_dir=self.tmpdir)
+
+        self.assertEqual(result, "OVERRIDE ONLY")
+        self.assertNotIn("SHOULD NOT APPEAR", result)
+
+    def test_no_prompts_dir_uses_default(self):
+        """
+        Test that omitting prompts_dir loads the default prompt (backwards compatible).
+        """
+        result_without = get_prompt('short_article', 'step1_system.txt')
+        result_with_none = get_prompt('short_article', 'step1_system.txt', prompts_dir=None)
+
+        self.assertEqual(result_without, result_with_none)
+        self.assertGreater(len(result_without), 0)
+
+    def test_empty_prompts_dir_uses_default(self):
+        """
+        Test that an empty prompts_dir falls through to the default prompt.
+        """
+        result_default = get_prompt('short_article', 'step1_system.txt')
+        result_empty_dir = get_prompt('short_article', 'step1_system.txt',
+                                      prompts_dir=self.tmpdir)
+
+        self.assertEqual(result_default, result_empty_dir)
+
+    def test_append_with_placeholders(self):
+        """
+        Test that append files support the same {placeholders}.
+        """
+        append_content = "Extra instructions for {source_language} to {target_language}."
+        append_path = os.path.join(self.tmpdir, 'step1_system_append.txt')
+        with open(append_path, 'w', encoding='utf-8') as f:
+            f.write(append_content)
+
+        result = get_prompt('short_article', 'step1_system.txt',
+                           prompts_dir=self.tmpdir,
+                           source_language='Spanish',
+                           target_language='English')
+
+        self.assertTrue(result.endswith("Extra instructions for Spanish to English."))
 
 
 if __name__ == '__main__':

--- a/tests/test_core_prompts.py
+++ b/tests/test_core_prompts.py
@@ -151,6 +151,20 @@ class TestPathTraversalValidation(unittest.TestCase):
 
     # --- dot and empty values ---
 
+    def test_rejects_backslash_separator(self):
+        """
+        Test that Windows-style backslash separators are rejected on all platforms.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('short_article', 'subdir\\step1_system.txt')
+
+    def test_rejects_workflow_backslash_separator(self):
+        """
+        Test that Windows-style backslash separators in workflow_name are rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('..\\core', 'step1_system.txt')
+
     def test_rejects_empty_filename(self):
         """
         Test that an empty file_name is rejected.

--- a/tests/test_core_prompts.py
+++ b/tests/test_core_prompts.py
@@ -107,12 +107,14 @@ class TestCorePrompts(unittest.TestCase):
 
 class TestPathTraversalValidation(unittest.TestCase):
     """
-    Test cases for path traversal protection in get_prompt().
+    Test cases for path traversal protection in get_prompt() and list_workflow_prompts().
     """
+
+    # --- file_name validation in get_prompt() ---
 
     def test_rejects_relative_path_traversal(self):
         """
-        Test that '../' path traversal attempts are rejected.
+        Test that '../' path traversal attempts in file_name are rejected.
         """
         with self.assertRaises(ValueError):
             get_prompt('short_article', '../etc/passwd')
@@ -142,11 +144,56 @@ class TestPathTraversalValidation(unittest.TestCase):
         """
         Test that a valid plain filename passes validation.
         """
-        # Should not raise ValueError (may raise FileNotFoundError if file doesn't exist)
         try:
             get_prompt('short_article', 'step1_system.txt')
         except ValueError:
             self.fail("get_prompt raised ValueError for a valid plain filename")
+
+    # --- workflow_name validation in get_prompt() ---
+
+    def test_rejects_workflow_traversal(self):
+        """
+        Test that '../' path traversal in workflow_name is rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('../core', 'step1_system.txt')
+
+    def test_rejects_workflow_subdirectory(self):
+        """
+        Test that workflow names with subdirectory separators are rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('short_article/prompts', 'step1_system.txt')
+
+    def test_rejects_workflow_absolute_path(self):
+        """
+        Test that absolute paths as workflow_name are rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('/etc', 'step1_system.txt')
+
+    def test_rejects_workflow_windows_drive(self):
+        """
+        Test that Windows drive-relative workflow names are rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('C:workflows', 'step1_system.txt')
+
+    # --- workflow_name validation in list_workflow_prompts() ---
+
+    def test_list_rejects_workflow_traversal(self):
+        """
+        Test that list_workflow_prompts rejects path traversal in workflow_name.
+        """
+        with self.assertRaises(ValueError):
+            list_workflow_prompts('../core')
+
+    def test_list_rejects_workflow_absolute_path(self):
+        """
+        Test that list_workflow_prompts rejects absolute workflow_name.
+        """
+        with self.assertRaises(ValueError):
+            list_workflow_prompts('/etc')
 
 
 class TestPromptOverrides(unittest.TestCase):

--- a/tests/test_core_prompts.py
+++ b/tests/test_core_prompts.py
@@ -6,7 +6,6 @@ across all workflows, including the prompt override system (prompts_dir).
 """
 
 import os
-import shutil
 import tempfile
 import unittest
 from unittest.mock import patch, MagicMock

--- a/tests/test_core_prompts.py
+++ b/tests/test_core_prompts.py
@@ -105,6 +105,50 @@ class TestCorePrompts(unittest.TestCase):
             self.assertTrue(prompt_file.endswith('.txt'))
 
 
+class TestPathTraversalValidation(unittest.TestCase):
+    """
+    Test cases for path traversal protection in get_prompt().
+    """
+
+    def test_rejects_relative_path_traversal(self):
+        """
+        Test that '../' path traversal attempts are rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('short_article', '../etc/passwd')
+
+    def test_rejects_subdirectory_path(self):
+        """
+        Test that file names containing subdirectory separators are rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('short_article', 'subdir/step1_system.txt')
+
+    def test_rejects_absolute_path(self):
+        """
+        Test that absolute file paths are rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('short_article', '/etc/passwd')
+
+    def test_rejects_windows_drive_relative_path(self):
+        """
+        Test that Windows drive-relative paths like 'C:foo.txt' are rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('short_article', 'C:foo.txt')
+
+    def test_accepts_plain_filename(self):
+        """
+        Test that a valid plain filename passes validation.
+        """
+        # Should not raise ValueError (may raise FileNotFoundError if file doesn't exist)
+        try:
+            get_prompt('short_article', 'step1_system.txt')
+        except ValueError:
+            self.fail("get_prompt raised ValueError for a valid plain filename")
+
+
 class TestPromptOverrides(unittest.TestCase):
     """
     Test cases for the prompt override system (prompts_dir).

--- a/tests/test_core_prompts.py
+++ b/tests/test_core_prompts.py
@@ -6,9 +6,13 @@ across all workflows, including the prompt override system (prompts_dir).
 """
 
 import os
+import shutil
 import tempfile
 import unittest
+from unittest.mock import patch, MagicMock
 from aphra.core.prompts import get_prompt, list_workflow_prompts
+from aphra.core.context import TranslationContext
+from aphra.core.workflow import AbstractWorkflow
 
 
 class TestCorePrompts(unittest.TestCase):
@@ -71,7 +75,7 @@ class TestCorePrompts(unittest.TestCase):
         prompts = list_workflow_prompts('short_article')
         self.assertIsInstance(prompts, list)
         self.assertGreater(len(prompts), 0)
-        
+
         # Check that expected files are present
         expected_files = [
             'step1_system.txt', 'step1_user.txt',
@@ -80,7 +84,7 @@ class TestCorePrompts(unittest.TestCase):
             'step4_system.txt', 'step4_user.txt',
             'step5_system.txt', 'step5_user.txt'
         ]
-        
+
         for expected_file in expected_files:
             self.assertIn(expected_file, prompts)
 
@@ -96,7 +100,7 @@ class TestCorePrompts(unittest.TestCase):
         Test that only .txt files are listed as prompts.
         """
         prompts = list_workflow_prompts('short_article')
-        
+
         # All files should have .txt extension
         for prompt_file in prompts:
             self.assertTrue(prompt_file.endswith('.txt'))
@@ -109,13 +113,12 @@ class TestPromptOverrides(unittest.TestCase):
 
     def setUp(self):
         """Create a temporary directory for prompt overrides."""
-        self.tmpdir = tempfile.mkdtemp()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = self._tmpdir.name
 
     def tearDown(self):
-        """Clean up temporary files."""
-        for f in os.listdir(self.tmpdir):
-            os.remove(os.path.join(self.tmpdir, f))
-        os.rmdir(self.tmpdir)
+        """Clean up temporary directory."""
+        self._tmpdir.cleanup()
 
     def test_full_override(self):
         """
@@ -183,11 +186,10 @@ class TestPromptOverrides(unittest.TestCase):
         self.assertTrue(result.startswith("BEFORE"))
         self.assertTrue(result.endswith("AFTER"))
 
-    def test_override_takes_priority_over_append(self):
+    def test_override_takes_priority_over_append_and_prepend(self):
         """
-        Test that a full override ignores append/prepend files.
+        Test that a full override ignores both append and prepend files.
         """
-        # Create all three: override, append, prepend
         override_path = os.path.join(self.tmpdir, 'step1_system.txt')
         with open(override_path, 'w', encoding='utf-8') as f:
             f.write("OVERRIDE ONLY")
@@ -195,6 +197,10 @@ class TestPromptOverrides(unittest.TestCase):
         append_path = os.path.join(self.tmpdir, 'step1_system_append.txt')
         with open(append_path, 'w', encoding='utf-8') as f:
             f.write("SHOULD NOT APPEAR")
+
+        prepend_path = os.path.join(self.tmpdir, 'step1_system_prepend.txt')
+        with open(prepend_path, 'w', encoding='utf-8') as f:
+            f.write("SHOULD NOT APPEAR EITHER")
 
         result = get_prompt('short_article', 'step1_system.txt',
                            prompts_dir=self.tmpdir)
@@ -237,6 +243,80 @@ class TestPromptOverrides(unittest.TestCase):
                            target_language='English')
 
         self.assertTrue(result.endswith("Extra instructions for Spanish to English."))
+
+
+class TestWorkflowPromptOverrideIntegration(unittest.TestCase):
+    """
+    Integration test: AbstractWorkflow.run() wires prompts_dir into self.get_prompt().
+    """
+
+    def setUp(self):
+        """Create a temporary directory and a concrete workflow for testing."""
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = self._tmpdir.name
+
+        # Create a minimal concrete workflow for testing
+        class DummyWorkflow(AbstractWorkflow):
+            def __init__(self):
+                super().__init__()
+                self.last_prompt = None
+
+            def get_workflow_name(self):
+                return "short_article"
+
+            def is_suitable_for(self, text, **kwargs):
+                return True
+
+            def execute(self, context, text):
+                # Use self.get_prompt() which should pick up prompts_dir
+                self.last_prompt = self.get_prompt('step1_system.txt')
+                return "done"
+
+        self.DummyWorkflow = DummyWorkflow
+
+    def tearDown(self):
+        """Clean up temporary directory."""
+        self._tmpdir.cleanup()
+
+    @patch('aphra.core.workflow.load_workflow_config')
+    def test_run_wires_prompts_dir_into_get_prompt(self, mock_load_config):
+        """
+        Test that run() reads prompts_dir from config and self.get_prompt() uses it.
+        """
+        # Create an override file
+        override_path = os.path.join(self.tmpdir, 'step1_system.txt')
+        with open(override_path, 'w', encoding='utf-8') as f:
+            f.write("OVERRIDDEN VIA WORKFLOW")
+
+        # Mock config to return our prompts_dir
+        mock_load_config.return_value = {
+            'writer': 'test-model',
+            'prompts_dir': self.tmpdir
+        }
+
+        workflow = self.DummyWorkflow()
+        context = MagicMock(spec=TranslationContext)
+
+        workflow.run(context, "test text")
+
+        self.assertEqual(workflow.last_prompt, "OVERRIDDEN VIA WORKFLOW")
+
+    @patch('aphra.core.workflow.load_workflow_config')
+    def test_run_without_prompts_dir_uses_defaults(self, mock_load_config):
+        """
+        Test that run() without prompts_dir in config uses default prompts.
+        """
+        mock_load_config.return_value = {'writer': 'test-model'}
+
+        workflow = self.DummyWorkflow()
+        context = MagicMock(spec=TranslationContext)
+
+        workflow.run(context, "test text")
+
+        # Should load the default prompt (non-empty)
+        self.assertIsNotNone(workflow.last_prompt)
+        self.assertGreater(len(workflow.last_prompt), 0)
+        self.assertNotEqual(workflow.last_prompt, "OVERRIDDEN VIA WORKFLOW")
 
 
 if __name__ == '__main__':

--- a/tests/test_core_prompts.py
+++ b/tests/test_core_prompts.py
@@ -149,6 +149,43 @@ class TestPathTraversalValidation(unittest.TestCase):
         except ValueError:
             self.fail("get_prompt raised ValueError for a valid plain filename")
 
+    # --- dot and empty values ---
+
+    def test_rejects_empty_filename(self):
+        """
+        Test that an empty file_name is rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('short_article', '')
+
+    def test_rejects_dot_filename(self):
+        """
+        Test that '.' as file_name is rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('short_article', '.')
+
+    def test_rejects_dotdot_filename(self):
+        """
+        Test that '..' as file_name is rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('short_article', '..')
+
+    def test_rejects_empty_workflow(self):
+        """
+        Test that an empty workflow_name is rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('', 'step1_system.txt')
+
+    def test_rejects_dotdot_workflow(self):
+        """
+        Test that '..' as workflow_name is rejected.
+        """
+        with self.assertRaises(ValueError):
+            get_prompt('..', 'step1_system.txt')
+
     # --- workflow_name validation in get_prompt() ---
 
     def test_rejects_workflow_traversal(self):


### PR DESCRIPTION
Introduce prompt override mechanism via a prompts_dir and a workflow-level helper.

- Implement robust prompt loading in aphra/core/prompts.py: supports full overrides ({prompts_dir}/{file}), prepend ({base}_prepend.txt) and append ({base}_append.txt), with formatting, fallbacks, and logging.
- Add AbstractWorkflow.get_prompt wrapper and store prompts_dir from workflow config so workflows can call self.get_prompt(...) to automatically respect user overrides.
- Update ShortArticleWorkflow to use self.get_prompt instead of importing get_prompt directly.
- Update docs (CONTRIBUTING.md, README.md) and config.example.toml to document prompts_dir usage and encourage implementing execute() and using self.get_prompt().
- Add comprehensive tests (tests/test_core_prompts.py) for override, prepend/append behavior, placeholder formatting, and fallback cases.

These changes allow users to customize or extend workflow prompts without modifying package code and make prompt usage simpler and backwards-compatible.